### PR TITLE
created a reproductable containerized development environment 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+  "name": "Pydemic UI Docker Compose",
+  "dockerComposeFile": ["../docker-compose.yml"],
+  "service": "pydemic-ui",
+  "workspaceFolder": "/app",
+  "settings": {
+    "terminal.integrated.shell.linux": null
+  },
+  "extensions": ["ms-python.python"]
+}

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,8 +5,14 @@ dist/
 notebooks/.ipynb_checkpoints/
 Untitled.ipynb
 cache
+.git
+*.pyc
+*.pyo
+*.pyd
+deploy-pydemic-ui/
 
-# docker-compose
+# docker
+Dockerfile
 docker-compose*
 
 # vscode

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ Untitled.ipynb
 cache
 
 # vscode
-.devcontainer*
 .vscode
 
 # gettext

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.8.5-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    FLIT_ROOT_INSTALL=1 
+
+COPY assets/locale.gen /etc/locale.gen
+
+RUN apt update && \
+    apt install -y git locales && \
+    locale-gen
+
+WORKDIR /app
+
+RUN pip --no-cache-dir install flit invoke
+
+COPY . .
+
+RUN flit install
+
+RUN pip uninstall -y pydemic-models
+RUN pip install git+https://github.com/GCES-Pydemic/pydemic.git
+
+RUN inv i18n
+
+CMD [ "inv", "run" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.8"
+services:
+  pydemic-ui:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      LANG: pt_BR.UTF-8
+      STREAMLIT_SERVER_ADDRESS: 0.0.0.0
+      STREAMLIT_SERVER_ENABLE_CORS: "false"
+    ports:
+      - "8501:8501"
+    volumes:
+      - .:/app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ requires = [
 dev = [
   "black",
   "twine",
+  "pycodestyle",
   "coverage~=5.0",
   "pytest~=5.0",
   "pytest-cov~=2.8",

--- a/tox.ini
+++ b/tox.ini
@@ -6,5 +6,5 @@ count = True
 # E203 Whitespace before ':'
 ignore = E731,W503,E501,E203
 max-doc-length = 100
-max-line-length = 100
+max-line-length = 90
 statistics = True


### PR DESCRIPTION
### What changed:
Used docker and docker compose to create a reproductable containerized development envinronment. 
Also added a `devcontainer.json` file to facilitate remote container development on vs-code

### To reproduce:

#### With Docker-Compose
- Have Docker and Docker Compose installed;
- Run the following command: `docker-compose up pydemic-ui`

#### With VSCode:
- Have the `ms-vscode-remote.remote-containers` vscode extension installed;
- After opening up the project with vscode select `Reopen in Container` on the pop up.

