### PR TITLE
Fixed wrong docker-compose command on README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ Docker Compose
 
 You can run the project using Docker Compose by having it installed and running the following command::
 
-    $ docker-compose up pydemic_ui
+    $ docker-compose up pydemic-ui
 
 VSCode Remote - Containers
 --------------------------


### PR DESCRIPTION
The command `docker-compose up pydemic_ui` could not run because the docker-compose service is called `pydemic-ui`, with an hyphen. So a fix has been added with the working command: `docker-compose up pydemic-ui`